### PR TITLE
feat(locals): add new ansible-openshift repository and update visibility for ansible-demo-content

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -10,6 +10,12 @@ locals {
       description = "Playbook content for various Ansible demos."
       name        = "ansible-demo-content"
       topics      = ["ansible"]
+      visibility  = "private"
+    },
+    "ansible-openshift" = {
+      description = "Ansible repository for managing OpenShift infrastructure."
+      name        = "ansible-openshift"
+      topics      = ["ansible", "openshift"]
       visibility  = "public"
     },
     "ansible-vmware" = {


### PR DESCRIPTION
- Added a new repository "ansible-openshift" with description and topics.
- Updated the visibility of "ansible-demo-content" to private.