### PR TITLE
refactor(locals): remove ansible-openshift and ansible-vmware, add ansible-homelab

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -12,17 +12,11 @@ locals {
       topics      = ["ansible"]
       visibility  = "private"
     },
-    "ansible-openshift" = {
-      description = "Ansible repository for managing OpenShift infrastructure."
-      name        = "ansible-openshift"
-      topics      = ["ansible", "openshift"]
-      visibility  = "public"
-    },
-    "ansible-vmware" = {
-      description = "Ansible repository for managing VMware infrastructure."
-      name        = "ansible-vmware"
-      topics      = ["ansible", "vmware"]
-      visibility  = "public"
+    "ansible-homelab" = {
+      description = "Playbook content for managing my homelab."
+      name        = "ansible-homelab"
+      topics      = ["ansible", "homelab"]
+      visibility  = "private"
     },
     "homernetes" = {
       description = "Configuration as code management of my home Kubernetes cluster."


### PR DESCRIPTION
Removed the ansible-openshift and ansible-vmware repositories. Added a new repository, ansible-homelab, for managing homelab infrastructure with private visibility.