### PR TITLE
feat: add new repository configuration for ocp-neptune

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -30,6 +30,12 @@ locals {
       topics      = ["configuration-as-code", "openshift"]
       visibility  = "public"
     },
+    "ocp-neptune" = {
+      description = "Configuration as code management of my compact OpenShift cluster."
+      name        = "ocp-neptune"
+      topics      = ["configuration-as-code", "openshift"]
+      visibility  = "public"
+    },
     "terraform-github" = {
       description = "Configuration as code management of organization repositories."
       name        = "terraform-github"


### PR DESCRIPTION
Added a new repository entry for "ocp-neptune" with description, name, topics, and visibility settings. This repository is for managing the configuration as code of a compact OpenShift cluster.